### PR TITLE
The `ServerIPv4` field will be used to specify the IP where the server will start. The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.  These modifications were tested and no compatibility issues were found.  This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -31,6 +31,7 @@ func init() {
 
 type UDRContext struct {
 	Name                                    string
+	ServerIPv4		  						string
 	UriScheme                               models.UriScheme
 	HttpIpv4Port                            int
 	HttpIPv4Address                         string

--- a/factory/config.go
+++ b/factory/config.go
@@ -19,6 +19,8 @@ type Info struct {
 type Configuration struct {
 	Sbi *Sbi `yaml:"sbi"`
 
+	ServerIPv4 string `yaml:"serverIPv4,omitempty"`
+
 	Mongodb *Mongodb `yaml:"mongodb"`
 
 	NrfUri string `yaml:"nrfUri"`

--- a/service/init.go
+++ b/service/init.go
@@ -115,7 +115,7 @@ func (udr *UDR) Start() {
 	self := udr_context.UDR_Self()
 	util.InitUdrContext(self)
 
-	addr := fmt.Sprintf("%s:%d", self.HttpIPv4Address, self.HttpIpv4Port)
+	addr := fmt.Sprintf("%s:%d", self.ServerIPv4, self.HttpIpv4Port)
 	profile := consumer.BuildNFInstance(self)
 	var newNrfUri string
 	var err error

--- a/util/init_context.go
+++ b/util/init_context.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"free5gc/lib/openapi/models"
 	udr_context "free5gc/src/udr/context"
 	"free5gc/src/udr/factory"
@@ -15,6 +16,15 @@ func InitUdrContext(context *udr_context.UDRContext) {
 	logger.UtilLog.Infof("udrconfig Info: Version[%s] Description[%s]", config.Info.Version, config.Info.Description)
 	configuration := config.Configuration
 	context.NfId = uuid.New().String()
+	context.ServerIPv4 = os.Getenv(configuration.ServerIPv4)
+	if context.ServerIPv4 == "" {
+		logger.UtilLog.Warn("Problem parsing ServerIPv4 address from ENV Variable. Trying to parse it as string.")
+		context.ServerIPv4 = configuration.ServerIPv4
+		if context.ServerIPv4 == "" {
+			logger.UtilLog.Warn("Error parsing ServerIPv4 address as string. Using the localhost address as default.")
+			context.ServerIPv4 = "127.0.0.1"
+		}
+	}
 	sbi := configuration.Sbi
 	context.UriScheme = models.UriScheme(sbi.Scheme)
 	context.HttpIPv4Address = "127.0.0.1" // default localhost
@@ -30,6 +40,7 @@ func InitUdrContext(context *udr_context.UDRContext) {
 	if configuration.NrfUri != "" {
 		context.NrfUri = configuration.NrfUri
 	} else {
-		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, context.HttpIPv4Address, 29510)
+		logger.UtilLog.Warn("NRF Uri is empty! Using localhost as NRF IPv4 address.")
+		context.NrfUri = fmt.Sprintf("%s://%s:%d", context.UriScheme, "127.0.0.1", 29510)
 	}
 }


### PR DESCRIPTION
The `ServerIPv4` field will be used to specify the IP where the server will start.
The difference that this field makes is that now the NFs can advertise a service IP (which is different from the NodeIP) in Kubernetes.

These modifications were tested and no compatibility issues were found.

This PR comes after the discussion here: https://github.com/free5gc/free5gc/issues/49#issuecomment-640213366