### PR TITLE
fix: PDU session cannot be established if DNN contains a period(.)

### DIFF
--- a/util/convert.go
+++ b/util/convert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"go.mongodb.org/mongo-driver/bson"
 
@@ -63,4 +64,12 @@ func SnssaiHexToModels(hexString string) (*models.Snssai, error) {
 func SnssaiModelsToHex(snssai models.Snssai) string {
 	sst := fmt.Sprintf("%02x", snssai.Sst)
 	return sst + snssai.Sd
+}
+
+func EscapeDnn(dnn string) string {
+	return strings.ReplaceAll(dnn, ".", "_")
+}
+
+func UnescapeDnn(dnnKey string) string {
+	return strings.ReplaceAll(dnnKey, "_", ".")
 }


### PR DESCRIPTION
- To replace all periods(.) in DNN to underscores(_) which is not available to be used in DNN before storing it into MongoDB.
- To replace all periods(.) in DNN to underscores(_) before calling MongoDB query API.
- To replace all underscores(_) of DNNs in the gotten data, from MongoDB by the query API, to periods(.).