### PR TITLE
fix(test): correct expected response for influenceData GET before creation

### DIFF
--- a/internal/sbi/api_sanity_test.go
+++ b/internal/sbi/api_sanity_test.go
@@ -268,7 +268,7 @@ func TestUDR_InfluData_GetBeforeCreateing(t *testing.T) {
 	t.Run("UDR influ-data Get before Create",
 		func(t *testing.T) {
 			require.Equal(t, http.StatusOK, rsp.Code)
-			require.Equal(t, "[1]", rsp.Body.String())
+			require.Equal(t, "[]", rsp.Body.String())
 		})
 }
 


### PR DESCRIPTION
- This test case PR in Apr 6, 2023
- https://github.com/free5gc/udr/pull/11
This test checks the /application-data/influenceData GET method before any data is created, so the expected response body should be []. However, the original test expected ["1"], which doesn't make sense in this context and has been corrected.

- Before change: test would fail
  - ![image](https://github.com/user-attachments/assets/33456694-31e3-4d0d-972b-36cc08212d25)

- After change: test success
  - ![image](https://github.com/user-attachments/assets/846ce458-b4bc-49ba-930c-e2a3cd9f6d2b)