### PR TITLE
fix: policydata-bdt-put-procedure

### DIFF
--- a/internal/sbi/processor/default.go
+++ b/internal/sbi/processor/default.go
@@ -133,7 +133,7 @@ func (p *Processor) PolicyDataBdtDataBdtReferenceIdPutProcedure(
 	if existed {
 		PreHandlePolicyDataChangeNotification("", bdtReferenceId, bdtData)
 	}
-	c.JSON(http.StatusOK, putData)
+	c.JSON(http.StatusCreated, putData)
 }
 
 func (p *Processor) PolicyDataBdtDataGetProcedure(c *gin.Context, collName string) {


### PR DESCRIPTION
Ref: https://github.com/free5gc/free5gc/issues/705
In spec, UDR need to response 201 in api /policy-data/bdt-data/:bdtReferenceId instead of 200