### PR TITLE
fix(callback): add OAuth2 token to outbound callback notifications

### DIFF
--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"context"
 	"fmt"
 	"runtime/debug"
 
@@ -100,8 +99,13 @@ func SendOnDataChangeNotify(ueId string, notifyItems []models.NotifyItem) {
 				subscriptionDataSubscription.OriginalCallbackReference,
 			}
 			dataChangeReq.DataChangeNotify.NotifyItems = notifyItems
+			ctx, pd, err := callbackRequestContext(onDataChangeNotifyUrl)
+			if err != nil {
+				logger.SBILog.Warnf("Get token for on-data-change callback failed: %+v", pd)
+				continue
+			}
 			rsp, err := client.SubsToNotifyCollectionApi.SubscriptionDataSubscriptionsOnDataChangePost(
-				context.TODO(), onDataChangeNotifyUrl, &dataChangeReq)
+				ctx, onDataChangeNotifyUrl, &dataChangeReq)
 
 			if err != nil {
 				logger.SBILog.Errorln(err.Error())
@@ -133,9 +137,14 @@ func SendPolicyDataChangeNotification(policyDataChangeNotification models.Policy
 				policyDataChangeNotification,
 			},
 		}
+		ctx, pd, err := callbackRequestContext(policyDataChangeNotificationUrl)
+		if err != nil {
+			logger.SBILog.Warnf("Get token for policy-data-change callback failed: %+v", pd)
+			continue
+		}
 
 		rsp, err := client.PolicyDataSubscriptionsCollectionApi.
-			CreateIndividualPolicyDataSubscriptionPolicyDataChangeNotificationPost(context.TODO(),
+			CreateIndividualPolicyDataSubscriptionPolicyDataChangeNotificationPost(ctx,
 				policyDataChangeNotificationUrl, &req)
 
 		if err != nil {
@@ -171,10 +180,15 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			req := DataRepository.CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPostRequest{
 				RequestBody: []interface{}{trafficInfluDataNotif},
 			}
+			ctx, pd, err := callbackRequestContext(influenceDataChangeNotificationUrl)
+			if err != nil {
+				logger.SBILog.Warnf("Get token for influence-data-update callback failed: %+v", pd)
+				return true
+			}
 
 			rsp, err := client.InfluenceDataSubscriptionsCollectionApi.
 				CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPost(
-					context.TODO(), influenceDataChangeNotificationUrl, &req)
+					ctx, influenceDataChangeNotificationUrl, &req)
 
 			if err != nil {
 				logger.SBILog.Errorln(err.Error())
@@ -190,10 +204,15 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			req := DataRepository.CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPostRequest{
 				RequestBody: []interface{}{trafficInfluDataNotif},
 			}
+			ctx, pd, err := callbackRequestContext(influenceDataChangeNotificationUrl)
+			if err != nil {
+				logger.SBILog.Warnf("Get token for influence-data-removal callback failed: %+v", pd)
+				return true
+			}
 
 			rsp, err := client.InfluenceDataSubscriptionsCollectionApi.
 				CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPost(
-					context.TODO(), influenceDataChangeNotificationUrl, &req)
+					ctx, influenceDataChangeNotificationUrl, &req)
 
 			if err != nil {
 				logger.SBILog.Errorln(err.Error())

--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -101,7 +101,7 @@ func SendOnDataChangeNotify(ueId string, notifyItems []models.NotifyItem) {
 			dataChangeReq.DataChangeNotify.NotifyItems = notifyItems
 			ctx, pd, err := callbackRequestContext(onDataChangeNotifyUrl)
 			if err != nil {
-				logger.SBILog.Warnf("Get token for on-data-change callback failed: %+v", pd)
+				logger.SBILog.Warnf("Get token for on-data-change callback failed: %+v, err: %v", pd, err)
 				continue
 			}
 			rsp, err := client.SubsToNotifyCollectionApi.SubscriptionDataSubscriptionsOnDataChangePost(
@@ -139,7 +139,7 @@ func SendPolicyDataChangeNotification(policyDataChangeNotification models.Policy
 		}
 		ctx, pd, err := callbackRequestContext(policyDataChangeNotificationUrl)
 		if err != nil {
-			logger.SBILog.Warnf("Get token for policy-data-change callback failed: %+v", pd)
+			logger.SBILog.Warnf("Get token for policy-data-change callback failed: %+v, err: %v", pd, err)
 			continue
 		}
 
@@ -182,7 +182,7 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			}
 			ctx, pd, err := callbackRequestContext(influenceDataChangeNotificationUrl)
 			if err != nil {
-				logger.SBILog.Warnf("Get token for influence-data-update callback failed: %+v", pd)
+				logger.SBILog.Warnf("Get token for influence-data-update callback failed: %+v, err: %v", pd, err)
 				return true
 			}
 
@@ -206,7 +206,7 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			}
 			ctx, pd, err := callbackRequestContext(influenceDataChangeNotificationUrl)
 			if err != nil {
-				logger.SBILog.Warnf("Get token for influence-data-removal callback failed: %+v", pd)
+				logger.SBILog.Warnf("Get token for influence-data-removal callback failed: %+v, err: %v", pd, err)
 				return true
 			}
 

--- a/internal/sbi/processor/callback_auth.go
+++ b/internal/sbi/processor/callback_auth.go
@@ -1,0 +1,60 @@
+package processor
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"github.com/free5gc/openapi/models"
+	udr_context "github.com/free5gc/udr/internal/context"
+)
+
+func callbackRequestContext(callbackURI string) (context.Context, *models.ProblemDetails, error) {
+	serviceName, targetNF, ok := callbackServiceInfo(callbackURI)
+	if !ok {
+		return context.TODO(), nil, nil
+	}
+	return udr_context.GetSelf().GetTokenCtx(serviceName, targetNF)
+}
+
+func callbackServiceInfo(callbackURI string) (models.ServiceName, models.NrfNfManagementNfType, bool) {
+	parsedURI, err := url.Parse(callbackURI)
+	if err != nil {
+		return "", "", false
+	}
+
+	path := strings.TrimPrefix(parsedURI.Path, "/")
+	if path == "" {
+		return "", "", false
+	}
+
+	serviceName := strings.SplitN(path, "/", 2)[0]
+	switch serviceName {
+	case "namf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_AMF, true
+	case "nausf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_AUSF, true
+	case "nsmf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_SMF, true
+	case "nudm-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_UDM, true
+	case "npcf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_PCF, true
+	case "nnef-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_NEF, true
+	case "nchf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_CHF, true
+	case "nbsf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_BSF, true
+	case "nnssf-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_NSSF, true
+	case "nudr-callback":
+		return models.ServiceName(serviceName), models.NrfNfManagementNfType_UDR, true
+	default:
+		pathParts := strings.Split(path, "/")
+		if len(pathParts) == 2 && pathParts[1] == "sdm-subscriptions" {
+			return models.ServiceName_NUDM_SDM, models.NrfNfManagementNfType_UDM, true
+		}
+		return "", "", false
+	}
+}

--- a/internal/sbi/processor/callback_auth_test.go
+++ b/internal/sbi/processor/callback_auth_test.go
@@ -36,8 +36,15 @@ func TestCallbackServiceInfo(t *testing.T) {
 			wantOK:      true,
 		},
 		{
-			name:        "udm sdm callback without callback prefix",
-			callbackURI: "http://udm.free5gc.org:8000/imsi-001010000000001/sdm-subscriptions",
+			name:        "udm sdm subscription-data create callback",
+			callbackURI: "http://udm.free5gc.org:8000/subscription-data/imsi-001010000000001/00101/sdm-subscriptions",
+			wantService: models.ServiceName_NUDM_SDM,
+			wantTarget:  models.NrfNfManagementNfType_UDM,
+			wantOK:      true,
+		},
+		{
+			name:        "udm sdm context-data update callback",
+			callbackURI: "http://udm.free5gc.org:8000/subscription-data/imsi-001010000000001/context-data/sdm-subscriptions/subs-1",
 			wantService: models.ServiceName_NUDM_SDM,
 			wantTarget:  models.NrfNfManagementNfType_UDM,
 			wantOK:      true,

--- a/internal/sbi/processor/callback_auth_test.go
+++ b/internal/sbi/processor/callback_auth_test.go
@@ -1,0 +1,71 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/free5gc/openapi/models"
+)
+
+func TestCallbackServiceInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		callbackURI string
+		wantService models.ServiceName
+		wantTarget  models.NrfNfManagementNfType
+		wantOK      bool
+	}{
+		{
+			name:        "pcf callback",
+			callbackURI: "http://pcf.free5gc.org:8000/npcf-callback/v1/nudr-notify/policy-data/imsi-001010000000001",
+			wantService: models.ServiceName("npcf-callback"),
+			wantTarget:  models.NrfNfManagementNfType_PCF,
+			wantOK:      true,
+		},
+		{
+			name:        "nef callback",
+			callbackURI: "http://nef.free5gc.org:8000/nnef-callback/v1/notification/smf",
+			wantService: models.ServiceName("nnef-callback"),
+			wantTarget:  models.NrfNfManagementNfType_NEF,
+			wantOK:      true,
+		},
+		{
+			name:        "smf callback without version segment",
+			callbackURI: "http://smf.free5gc.org:8000/nsmf-callback/sm-policies/imsi-001010000000001-10",
+			wantService: models.ServiceName("nsmf-callback"),
+			wantTarget:  models.NrfNfManagementNfType_SMF,
+			wantOK:      true,
+		},
+		{
+			name:        "udm sdm callback without callback prefix",
+			callbackURI: "http://udm.free5gc.org:8000/imsi-001010000000001/sdm-subscriptions",
+			wantService: models.ServiceName_NUDM_SDM,
+			wantTarget:  models.NrfNfManagementNfType_UDM,
+			wantOK:      true,
+		},
+		{
+			name:        "unknown path",
+			callbackURI: "http://example.com/custom/notify",
+			wantOK:      false,
+		},
+		{
+			name:        "invalid uri",
+			callbackURI: "://bad uri",
+			wantOK:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotService, gotTarget, gotOK := callbackServiceInfo(tc.callbackURI)
+			if gotOK != tc.wantOK {
+				t.Fatalf("callbackServiceInfo(%q) ok = %v, want %v", tc.callbackURI, gotOK, tc.wantOK)
+			}
+			if gotService != tc.wantService {
+				t.Fatalf("callbackServiceInfo(%q) service = %q, want %q", tc.callbackURI, gotService, tc.wantService)
+			}
+			if gotTarget != tc.wantTarget {
+				t.Fatalf("callbackServiceInfo(%q) target = %q, want %q", tc.callbackURI, gotTarget, tc.wantTarget)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  **Problem**
  - UDR outbound callback notification paths sent requests with `context.TODO()` directly, so no OAuth2
  bearer token was attached.
  - This affected on-data-change, policy-data-change, and influence-data-change notifications.
  - Once receiver-side callback auth is enforced, these notifications would fail unless UDR attaches a token
  first.

  **Changes**
  - `internal/sbi/processor/callback.go`: replace direct `context.TODO()` callback requests with token-aware
  callback contexts
  - `internal/sbi/processor/callback_auth.go`: add helper to infer callback service scope and target NF type
  from callback URIs
  - `internal/sbi/processor/callback_auth_test.go`: add unit coverage for callback URI inference, including
  known callback routes and negative cases

Fix: https://github.com/free5gc/free5gc/issues/888