### PR TITLE
fix: UDR panic/crash paths for #919 #920 #922 #923

### DIFF
--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -81,8 +81,7 @@ func PreHandleInfluenceDataUpdateNotification(influenceId string, original, modi
 func SendOnDataChangeNotify(ueId string, notifyItems []models.NotifyItem) {
 	defer func() {
 		if p := recover(); p != nil {
-			// Print stack for panic to log. Fatalf() will let program exit.
-			logger.HttpLog.Fatalf("panic: %v\n%s", p, string(debug.Stack()))
+			logger.HttpLog.Errorf("panic: %v\n%s", p, string(debug.Stack()))
 		}
 	}()
 
@@ -94,12 +93,15 @@ func SendOnDataChangeNotify(ueId string, notifyItems []models.NotifyItem) {
 		if ueId == subscriptionDataSubscription.UeId {
 			onDataChangeNotifyUrl := subscriptionDataSubscription.CallbackReference
 
-			dataChangeReq := DataRepository.SubscriptionDataSubscriptionsOnDataChangePostRequest{}
-			dataChangeReq.DataChangeNotify.UeId = ueId
-			dataChangeReq.DataChangeNotify.OriginalCallbackReference = []string{
-				subscriptionDataSubscription.OriginalCallbackReference,
+			dataChangeReq := DataRepository.SubscriptionDataSubscriptionsOnDataChangePostRequest{
+				DataChangeNotify: &models.DataChangeNotify{
+					UeId: ueId,
+					OriginalCallbackReference: []string{
+						subscriptionDataSubscription.OriginalCallbackReference,
+					},
+					NotifyItems: notifyItems,
+				},
 			}
-			dataChangeReq.DataChangeNotify.NotifyItems = notifyItems
 			rsp, err := client.SubsToNotifyCollectionApi.SubscriptionDataSubscriptionsOnDataChangePost(
 				context.TODO(), onDataChangeNotifyUrl, &dataChangeReq)
 
@@ -133,7 +135,6 @@ func SendPolicyDataChangeNotification(policyDataChangeNotification models.Policy
 				policyDataChangeNotification,
 			},
 		}
-
 		rsp, err := client.PolicyDataSubscriptionsCollectionApi.
 			CreateIndividualPolicyDataSubscriptionPolicyDataChangeNotificationPost(context.TODO(),
 				policyDataChangeNotificationUrl, &req)
@@ -171,7 +172,6 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			req := DataRepository.CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPostRequest{
 				RequestBody: []interface{}{trafficInfluDataNotif},
 			}
-
 			rsp, err := client.InfluenceDataSubscriptionsCollectionApi.
 				CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPost(
 					context.TODO(), influenceDataChangeNotificationUrl, &req)
@@ -190,7 +190,6 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			req := DataRepository.CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPostRequest{
 				RequestBody: []interface{}{trafficInfluDataNotif},
 			}
-
 			rsp, err := client.InfluenceDataSubscriptionsCollectionApi.
 				CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPost(
 					context.TODO(), influenceDataChangeNotificationUrl, &req)

--- a/internal/sbi/processor/event_amf_subscription_info_document.go
+++ b/internal/sbi/processor/event_amf_subscription_info_document.go
@@ -51,22 +51,28 @@ func (p *Processor) CreateAMFSubscriptionsProcedure(c *gin.Context, subsId strin
 func (p *Processor) RemoveAmfSubscriptionsInfoProcedure(c *gin.Context, subsId string, ueId string) {
 	udrSelf := udr_context.GetSelf()
 	value, ok := udrSelf.UESubsCollection.Load(ueId)
-	var pd *models.ProblemDetails = nil
+	var pd *models.ProblemDetails
 
 	if !ok {
 		pd = util.ProblemDetailsNotFound("USER_NOT_FOUND")
 		logger.DataRepoLog.Errorf("RemoveAmfSubscriptionsInfoProcedure err: %s", pd.Detail)
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
 	}
 
 	UESubsData := value.(*udr_context.UESubsData)
-	_, ok = UESubsData.EeSubscriptionCollection[subsId]
+	eeSub, ok := UESubsData.EeSubscriptionCollection[subsId]
 
 	if !ok {
 		pd = util.ProblemDetailsNotFound("SUBSCRIPTION_NOT_FOUND")
 		logger.DataRepoLog.Errorf("RemoveAmfSubscriptionsInfoProcedure err: %s", pd.Detail)
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
 	}
 
-	if UESubsData.EeSubscriptionCollection[subsId].AmfSubscriptionInfos == nil {
+	if eeSub == nil || eeSub.AmfSubscriptionInfos == nil {
 		pd = util.ProblemDetailsNotFound("AMFSUBSCRIPTION_NOT_FOUND")
 	}
 

--- a/internal/sbi/processor/provisioned_data_document.go
+++ b/internal/sbi/processor/provisioned_data_document.go
@@ -118,14 +118,17 @@ func (p *Processor) QueryProvisionedDataProcedure(c *gin.Context, ueId string, s
 			c.JSON(http.StatusInternalServerError, problemDetails)
 			return
 		}
-		for _, smData := range tmp {
-			dnnConfigurations := smData.DnnConfigurations
+		for i := range tmp {
+			dnnConfigurations := tmp[i].DnnConfigurations
 			tmpDnnConfigurations := make(map[string]models.DnnConfiguration)
 			for escapedDnn, dnnConf := range dnnConfigurations {
 				dnn := util.UnescapeDnn(escapedDnn)
 				tmpDnnConfigurations[dnn] = dnnConf
 			}
-			smData.DnnConfigurations = tmpDnnConfigurations
+			tmp[i].DnnConfigurations = tmpDnnConfigurations
+		}
+		if provisionedDataSets.SmData == nil {
+			provisionedDataSets.SmData = &models.SmSubsData{}
 		}
 		provisionedDataSets.SmData.IndividualSmSubsData = tmp
 	}


### PR DESCRIPTION
**Remove AMF Subscription Panic:** https://github.com/free5gc/free5gc/issues/919, https://github.com/free5gc/free5gc/issues/920

File: `internal/sbi/processor/event_amf_subscription_info_document.go`

Problem:
- The code continued execution even when UE state or subsId was missing.
- It then asserted/dereferenced nil values, causing panic.

Fix:
- Return immediately after `USER_NOT_FOUND`.
- Return immediately after `SUBSCRIPTION_NOT_FOUND`.
- Guard the map value with `eeSub == nil` check before reading `AmfSubscriptionInfos`.
---

**Provisioned Data Panic:** https://github.com/free5gc/free5gc/issues/922

File: `internal/sbi/processor/provisioned_data_document.go`

Problem:
- `provisionedDataSets.SmData` is a pointer and was not initialized before assigning `IndividualSmSubsData`.
- Also, DNN rewrite loop modified a range-copy, so updates were not persisted.

Fix:
- Initialize `SmData` when nil before writing into it.
- Iterate by index (`for i := range tmp`) and update `tmp[i]` directly.
---

**On-Data-Change Callback Crash:** https://github.com/free5gc/free5gc/issues/923

File: `internal/sbi/processor/callback.go`

Problem:
- `DataChangeNotify` pointer inside request struct was never initialized before field writes.
- Panic recovery used `Fatalf`, which terminates the process.

Fix:
- Build request with initialized `DataChangeNotify` object.
- Change recover logging from `Fatalf` to `Errorf`.