### PR TITLE
fix: crash at concurrent map writes

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -217,6 +217,17 @@ func (context *UDRContext) NewAppDataInfluDataSubscriptionID() uint64 {
 	return context.appDataInfluDataSubscriptionIdGenerator
 }
 
+func (context *UDRContext) CreatePolicyDataSubscription(policyDataSubscription models.PolicyDataSubscription) string {
+	context.mtx.Lock()
+	defer context.mtx.Unlock()
+
+	newSubscriptionID := strconv.Itoa(context.PolicyDataSubscriptionIDGenerator)
+	context.PolicyDataSubscriptions[newSubscriptionID] = &policyDataSubscription
+	context.PolicyDataSubscriptionIDGenerator++
+
+	return newSubscriptionID
+}
+
 func NewInfluenceDataSubscriptionId() string {
 	if GetSelf().InfluenceDataSubscriptionIDGenerator == nil {
 		GetSelf().InfluenceDataSubscriptionIDGenerator = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -68,7 +68,7 @@ type UDRContext struct {
 	PolicyDataSubscriptions                 map[subsId]*models.PolicyDataSubscription
 	InfluenceDataSubscriptions              sync.Map
 	appDataInfluDataSubscriptionIdGenerator uint64
-	mtx                                     sync.RWMutex
+	mtx                                     sync.RWMutex // context-level lock for mutable UDRContext state
 	OAuth2Required                          bool
 }
 

--- a/internal/sbi/api_datarepository.go
+++ b/internal/sbi/api_datarepository.go
@@ -1421,20 +1421,8 @@ func (s *Server) HandlePolicyDataSponsorConnectivityDataSponsorIdGet(c *gin.Cont
 func (s *Server) HandlePolicyDataSubsToNotifyPost(c *gin.Context) {
 	var policyDataSubscription models.PolicyDataSubscription
 
-	reqBody, err := c.GetRawData()
-	if err != nil {
-		logger.DataRepoLog.Errorf("Get Request Body error: %+v", err)
-		pd := openapi.ProblemDetailsSystemFailure(err.Error())
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
-		c.JSON(http.StatusInternalServerError, pd)
-	}
-
-	err = openapi.Deserialize(policyDataSubscription, reqBody, "application/json")
-	if err != nil {
-		logger.DataRepoLog.Errorf("Deserialize Request Body error: %+v", err)
-		pd := util.ProblemDetailsMalformedReqSyntax(err.Error())
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
-		c.JSON(http.StatusBadRequest, pd)
+	if err := getDataFromRequestBody(c, &policyDataSubscription); err != nil {
+		return
 	}
 
 	logger.DataRepoLog.Tracef("Handle PolicyDataSubsToNotifyPost")
@@ -1453,20 +1441,8 @@ func (s *Server) HandlePolicyDataSubsToNotifySubsIdDelete(c *gin.Context) {
 func (s *Server) HandlePolicyDataSubsToNotifySubsIdPut(c *gin.Context) {
 	var policyDataSubscription models.PolicyDataSubscription
 
-	reqBody, err := c.GetRawData()
-	if err != nil {
-		logger.DataRepoLog.Errorf("Get Request Body error: %+v", err)
-		pd := openapi.ProblemDetailsSystemFailure(err.Error())
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
-		c.JSON(http.StatusInternalServerError, pd)
-	}
-
-	err = openapi.Deserialize(policyDataSubscription, reqBody, "application/json")
-	if err != nil {
-		logger.DataRepoLog.Errorf("Deserialize Request Body error: %+v", err)
-		pd := util.ProblemDetailsMalformedReqSyntax(err.Error())
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
-		c.JSON(http.StatusBadRequest, pd)
+	if err := getDataFromRequestBody(c, &policyDataSubscription); err != nil {
+		return
 	}
 
 	logger.DataRepoLog.Tracef("Handle PolicyDataSubsToNotifySubsIdPut")

--- a/internal/sbi/processor/default.go
+++ b/internal/sbi/processor/default.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -180,9 +179,7 @@ func (p *Processor) PolicyDataSubsToNotifyPostProcedure(
 ) {
 	udrSelf := udr_context.GetSelf()
 
-	newSubscriptionID := strconv.Itoa(udrSelf.PolicyDataSubscriptionIDGenerator)
-	udrSelf.PolicyDataSubscriptions[newSubscriptionID] = &PolicyDataSubscription
-	udrSelf.PolicyDataSubscriptionIDGenerator++
+	newSubscriptionID := udrSelf.CreatePolicyDataSubscription(PolicyDataSubscription)
 
 	/* Contains the URI of the newly created resource, according
 	   to the structure: {apiRoot}/subscription-data/subs-to-notify/{subsId} */


### PR DESCRIPTION
Fix UDR `policy-data/subs-to-notify` crash at concurrent map writes: free5gc/free5gc#921

Files:
- `internal/sbi/api_datarepository.go`
- `internal/sbi/processor/default.go`
- `internal/context/context.go`

Problem:
- Malformed request handling in `POST/PUT /nudr-dr/v2/policy-data/subs-to-notify` could fall through after error handling.
- Subscription creation wrote shared in-memory state (`PolicyDataSubscriptions` + ID counter) without synchronization.
- Concurrent POST traffic could trigger `fatal error: concurrent map writes` and terminate UDR.

Fix:
- Reused common request-body parsing and return immediately on parse errors.
- Added synchronized subscription creation helper in UDR context.
- Switched POST subscription creation to use the synchronized helper.