### PR TITLE
fix: attach OAuth2 token to outbound callbacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/free5gc/openapi v1.2.4
 	github.com/free5gc/util v1.3.2
 	github.com/gin-gonic/gin v1.10.0
+	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang/mock v1.4.4
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -42,7 +43,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/h2non/gock v1.2.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -32,8 +32,8 @@ func Init() {
 	udrContext.SdmSubscriptionIDGenerator = 1
 	udrContext.SubscriptionDataSubscriptionIDGenerator = 1
 	udrContext.PolicyDataSubscriptionIDGenerator = 1
-	udrContext.SubscriptionDataSubscriptions = make(map[subsId]*models.SubscriptionDataSubscriptions)
-	udrContext.PolicyDataSubscriptions = make(map[subsId]*models.PolicyDataSubscription)
+	udrContext.SubscriptionDataSubscriptions = make(map[subsId]*SubscriptionDataSubscriptionRecord)
+	udrContext.PolicyDataSubscriptions = make(map[subsId]*PolicyDataSubscriptionRecord)
 	udrContext.InfluenceDataSubscriptionIDGenerator = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 
 	serviceName := []models.ServiceName{
@@ -64,11 +64,11 @@ type UDRContext struct {
 	InfluenceDataSubscriptionIDGenerator    *rand.Rand
 	UESubsCollection                        sync.Map // map[ueId]*UESubsData
 	UEGroupCollection                       sync.Map // map[ueGroupId]*UEGroupSubsData
-	SubscriptionDataSubscriptions           map[subsId]*models.SubscriptionDataSubscriptions
-	PolicyDataSubscriptions                 map[subsId]*models.PolicyDataSubscription
+	SubscriptionDataSubscriptions           map[subsId]*SubscriptionDataSubscriptionRecord
+	PolicyDataSubscriptions                 map[subsId]*PolicyDataSubscriptionRecord
 	InfluenceDataSubscriptions              sync.Map
 	appDataInfluDataSubscriptionIdGenerator uint64
-	mtx                                     sync.RWMutex // context-level lock for mutable UDRContext state
+	mtx                                     sync.RWMutex
 	OAuth2Required                          bool
 }
 
@@ -84,6 +84,27 @@ type UEGroupSubsData struct {
 type EeSubscriptionCollection struct {
 	EeSubscriptions      *models.EeSubscription
 	AmfSubscriptionInfos []models.AmfSubscriptionInfo
+}
+
+type SubscriptionCallbackTarget struct {
+	ServiceName  models.ServiceName
+	NfType       models.NrfNfManagementNfType
+	NfInstanceID string
+}
+
+type SubscriptionDataSubscriptionRecord struct {
+	Subscription   *models.SubscriptionDataSubscriptions
+	CallbackTarget SubscriptionCallbackTarget
+}
+
+type PolicyDataSubscriptionRecord struct {
+	Subscription   *models.PolicyDataSubscription
+	CallbackTarget SubscriptionCallbackTarget
+}
+
+type InfluenceDataSubscriptionRecord struct {
+	Subscription   *models.TrafficInfluSub
+	CallbackTarget SubscriptionCallbackTarget
 }
 
 type NFContext interface {
@@ -217,17 +238,6 @@ func (context *UDRContext) NewAppDataInfluDataSubscriptionID() uint64 {
 	return context.appDataInfluDataSubscriptionIdGenerator
 }
 
-func (context *UDRContext) CreatePolicyDataSubscription(policyDataSubscription models.PolicyDataSubscription) string {
-	context.mtx.Lock()
-	defer context.mtx.Unlock()
-
-	newSubscriptionID := strconv.Itoa(context.PolicyDataSubscriptionIDGenerator)
-	context.PolicyDataSubscriptions[newSubscriptionID] = &policyDataSubscription
-	context.PolicyDataSubscriptionIDGenerator++
-
-	return newSubscriptionID
-}
-
 func NewInfluenceDataSubscriptionId() string {
 	if GetSelf().InfluenceDataSubscriptionIDGenerator == nil {
 		GetSelf().InfluenceDataSubscriptionIDGenerator = rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
@@ -243,6 +253,10 @@ func (c *UDRContext) GetTokenCtx(serviceName models.ServiceName, targetNF models
 	}
 	return oauth.GetTokenCtx(models.NrfNfManagementNfType_UDR, targetNF,
 		c.NfId, c.NrfUri, string(serviceName))
+}
+
+func (c *UDRContext) OAuth2Enabled() bool {
+	return c.OAuth2Required
 }
 
 func (c *UDRContext) AuthorizationCheck(token string, serviceName models.ServiceName) error {

--- a/internal/sbi/processor/callback.go
+++ b/internal/sbi/processor/callback.go
@@ -14,6 +14,26 @@ import (
 
 var CurrentResourceUri string
 
+func getCallbackTokenCtx(
+	serviceName models.ServiceName,
+	targetNF models.NrfNfManagementNfType,
+	operation string,
+) (context.Context, bool) {
+	ctx, pd, err := udr_context.GetSelf().GetTokenCtx(serviceName, targetNF)
+	if err != nil {
+		logger.SBILog.Errorf("%s get token failed: %v", operation, err)
+		if pd != nil {
+			logger.SBILog.Errorf("%s get token problem details: %+v", operation, pd)
+		}
+		return nil, false
+	}
+	if pd != nil {
+		logger.SBILog.Errorf("%s get token problem details: %+v", operation, pd)
+		return nil, false
+	}
+	return ctx, true
+}
+
 func PreHandleOnDataChangeNotify(ueId string, resourceId string, patchItems []models.PatchItem,
 	origValue map[string]interface{}, newValue map[string]interface{},
 ) {
@@ -86,17 +106,25 @@ func SendOnDataChangeNotify(ueId string, notifyItems []models.NotifyItem) {
 	}()
 
 	udrSelf := udr_context.GetSelf()
-	ctx, pd, err := udrSelf.GetTokenCtx(models.ServiceName_NUDM_SDM, models.NrfNfManagementNfType_UDM)
-	if err != nil {
-		logger.SBILog.Errorf("SendOnDataChangeNotify get token failed: %+v", pd)
-		return
-	}
-
 	configuration := DataRepository.NewConfiguration()
 	client := DataRepository.NewAPIClient(configuration)
 
-	for _, subscriptionDataSubscription := range udrSelf.SubscriptionDataSubscriptions {
+	for _, record := range udrSelf.SubscriptionDataSubscriptions {
+		if record == nil || record.Subscription == nil {
+			logger.SBILog.Errorln("Invalid subscription data subscription record")
+			continue
+		}
+		subscriptionDataSubscription := record.Subscription
 		if ueId == subscriptionDataSubscription.UeId {
+			ctx, ok := getCallbackTokenCtx(
+				record.CallbackTarget.ServiceName,
+				record.CallbackTarget.NfType,
+				"SendOnDataChangeNotify",
+			)
+			if !ok {
+				continue
+			}
+
 			onDataChangeNotifyUrl := subscriptionDataSubscription.CallbackReference
 
 			dataChangeReq := DataRepository.SubscriptionDataSubscriptionsOnDataChangePostRequest{
@@ -130,7 +158,21 @@ func SendPolicyDataChangeNotification(policyDataChangeNotification models.Policy
 
 	udrSelf := udr_context.GetSelf()
 
-	for _, policyDataSubscription := range udrSelf.PolicyDataSubscriptions {
+	for _, record := range udrSelf.PolicyDataSubscriptions {
+		if record == nil || record.Subscription == nil {
+			logger.SBILog.Errorln("Invalid policy data subscription record")
+			continue
+		}
+		ctx, ok := getCallbackTokenCtx(
+			record.CallbackTarget.ServiceName,
+			record.CallbackTarget.NfType,
+			"SendPolicyDataChangeNotification",
+		)
+		if !ok {
+			continue
+		}
+
+		policyDataSubscription := record.Subscription
 		policyDataChangeNotificationUrl := policyDataSubscription.NotificationUri
 
 		configuration := DataRepository.NewConfiguration()
@@ -142,7 +184,7 @@ func SendPolicyDataChangeNotification(policyDataChangeNotification models.Policy
 			},
 		}
 		rsp, err := client.PolicyDataSubscriptionsCollectionApi.
-			CreateIndividualPolicyDataSubscriptionPolicyDataChangeNotificationPost(context.TODO(),
+			CreateIndividualPolicyDataSubscriptionPolicyDataChangeNotificationPost(ctx,
 				policyDataChangeNotificationUrl, &req)
 
 		if err != nil {
@@ -162,9 +204,18 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 	var trafficInfluDataNotif models.TrafficInfluDataNotif
 	trafficInfluDataNotif.ResUri = resUri
 	udrSelf.InfluenceDataSubscriptions.Range(func(key, value interface{}) bool {
-		influenceDataSubscription, ok := value.(*models.TrafficInfluSub)
-		if !ok {
+		record, ok := value.(*udr_context.InfluenceDataSubscriptionRecord)
+		if !ok || record.Subscription == nil {
 			logger.HttpLog.Errorf("Failed to load influenceData subscription ID [%+v]", key)
+			return true
+		}
+		influenceDataSubscription := record.Subscription
+		ctx, ok := getCallbackTokenCtx(
+			record.CallbackTarget.ServiceName,
+			record.CallbackTarget.NfType,
+			"SendInfluenceDataUpdateNotification",
+		)
+		if !ok {
 			return true
 		}
 		influenceDataChangeNotificationUrl := influenceDataSubscription.NotificationUri
@@ -180,7 +231,7 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			}
 			rsp, err := client.InfluenceDataSubscriptionsCollectionApi.
 				CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPost(
-					context.TODO(), influenceDataChangeNotificationUrl, &req)
+					ctx, influenceDataChangeNotificationUrl, &req)
 
 			if err != nil {
 				logger.SBILog.Errorln(err.Error())
@@ -198,7 +249,7 @@ func SendInfluenceDataUpdateNotification(resUri string, original, modified *mode
 			}
 			rsp, err := client.InfluenceDataSubscriptionsCollectionApi.
 				CreateIndividualInfluenceDataSubscriptionTrafficInfluenceDataChangeNotificationPost(
-					context.TODO(), influenceDataChangeNotificationUrl, &req)
+					ctx, influenceDataChangeNotificationUrl, &req)
 
 			if err != nil {
 				logger.SBILog.Errorln(err.Error())

--- a/internal/sbi/processor/default.go
+++ b/internal/sbi/processor/default.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -179,7 +180,21 @@ func (p *Processor) PolicyDataSubsToNotifyPostProcedure(
 ) {
 	udrSelf := udr_context.GetSelf()
 
-	newSubscriptionID := udrSelf.CreatePolicyDataSubscription(PolicyDataSubscription)
+	newSubscriptionID := strconv.Itoa(udrSelf.PolicyDataSubscriptionIDGenerator)
+	target, ok := subscriptionCallbackTargetFromContext(
+		c,
+		models.ServiceName_NPCF_SMPOLICYCONTROL,
+		models.NrfNfManagementNfType_PCF,
+	)
+	if !ok {
+		rejectUnresolvedCallbackTarget(c)
+		return
+	}
+	udrSelf.PolicyDataSubscriptions[newSubscriptionID] = &udr_context.PolicyDataSubscriptionRecord{
+		Subscription:   &PolicyDataSubscription,
+		CallbackTarget: target,
+	}
+	udrSelf.PolicyDataSubscriptionIDGenerator++
 
 	/* Contains the URI of the newly created resource, according
 	   to the structure: {apiRoot}/subscription-data/subs-to-notify/{subsId} */
@@ -215,7 +230,14 @@ func (p *Processor) PolicyDataSubsToNotifySubsIdPutProcedure(c *gin.Context, sub
 		return
 	}
 
-	udrSelf.PolicyDataSubscriptions[subsId] = &policyDataSubscription
+	record := udrSelf.PolicyDataSubscriptions[subsId]
+	if record == nil {
+		pd := util.ProblemDetailsNotFound("SUBSCRIPTION_NOT_FOUND")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
+	}
+	record.Subscription = &policyDataSubscription
 	c.JSON(http.StatusOK, policyDataSubscription)
 }
 

--- a/internal/sbi/processor/individual_influence_data_subscription_document.go
+++ b/internal/sbi/processor/individual_influence_data_subscription_document.go
@@ -32,8 +32,16 @@ func (p *Processor) ApplicationDataInfluenceDataSubsToNotifySubscriptionIdGetPro
 	c *gin.Context, subscriptionID string,
 ) {
 	udrSelf := udr_context.GetSelf()
-	if subscription, ok := udrSelf.InfluenceDataSubscriptions.Load(subscriptionID); ok {
-		c.JSON(http.StatusOK, subscription)
+	if value, ok := udrSelf.InfluenceDataSubscriptions.Load(subscriptionID); ok {
+		record, valid := value.(*udr_context.InfluenceDataSubscriptionRecord)
+		if valid && record.Subscription != nil {
+			c.JSON(http.StatusOK, record.Subscription)
+			return
+		}
+		pd := util.ProblemDetailsNotFound("USER_NOT_FOUND")
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+		c.JSON(int(pd.Status), pd)
+		return
 	} else {
 		pd := util.ProblemDetailsNotFound("USER_NOT_FOUND")
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
@@ -68,10 +76,28 @@ func (p *Processor) ApplicationDataInfluenceDataSubsToNotifySubscriptionIdPutPro
 	}
 
 	udrSelf := udr_context.GetSelf()
-	if subs, ok := udrSelf.InfluenceDataSubscriptions.Load(subscriptionId); ok && reflect.DeepEqual(*request, subs) {
-		c.Status(http.StatusOK)
-	} else {
-		udrSelf.InfluenceDataSubscriptions.Store(subscriptionId, request)
-		c.JSON(http.StatusOK, request)
+	target, ok := subscriptionCallbackTargetFromContext(
+		c,
+		models.ServiceName_NPCF_SMPOLICYCONTROL,
+		models.NrfNfManagementNfType_PCF,
+	)
+	if !ok {
+		rejectUnresolvedCallbackTarget(c)
+		return
 	}
+	if value, ok := udrSelf.InfluenceDataSubscriptions.Load(subscriptionId); ok {
+		record, valid := value.(*udr_context.InfluenceDataSubscriptionRecord)
+		if valid {
+			target = record.CallbackTarget
+			if record.Subscription != nil && reflect.DeepEqual(*request, *record.Subscription) {
+				c.Status(http.StatusOK)
+				return
+			}
+		}
+	}
+	udrSelf.InfluenceDataSubscriptions.Store(subscriptionId, &udr_context.InfluenceDataSubscriptionRecord{
+		Subscription:   request,
+		CallbackTarget: target,
+	})
+	c.JSON(http.StatusOK, request)
 }

--- a/internal/sbi/processor/influence_data_subscriptions_collection.go
+++ b/internal/sbi/processor/influence_data_subscriptions_collection.go
@@ -33,11 +33,13 @@ func (p *Processor) ApplicationDataInfluenceDataSubsToNotifyGetProcedure(
 
 	udrSelf := udr_context.GetSelf()
 	udrSelf.InfluenceDataSubscriptions.Range(func(key, value interface{}) bool {
-		subs, ok := value.(*models.TrafficInfluSub)
-		if !ok {
+		record, ok := value.(*udr_context.InfluenceDataSubscriptionRecord)
+		if !ok || record.Subscription == nil {
 			logger.DataRepoLog.Errorf("Failed to load influence Data subscription ID [%+v]", key)
 			return true
-		} else if dnn != "" && !util.Contain(dnn, subs.Dnns) {
+		}
+		subs := record.Subscription
+		if dnn != "" && !util.Contain(dnn, subs.Dnns) {
 			return true
 		} else if snssai != nil && !util.Contain(*snssai, subs.Snssais) {
 			return true
@@ -81,22 +83,41 @@ func (p *Processor) ApplicationDataInfluenceDataSubsToNotifySubscriptionIdPostPr
 	}
 
 	udrSelf := udr_context.GetSelf()
-	if subs, ok := udrSelf.InfluenceDataSubscriptions.Load(subscriptionId); ok && reflect.DeepEqual(*request, subs) {
-		pd := &models.ProblemDetails{
-			Status: http.StatusForbidden,
-			Cause:  "UNSPECIFIED",
-		}
-		c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
-		c.JSON(int(pd.Status), pd)
-	} else {
-		udrSelf.InfluenceDataSubscriptions.Store(subscriptionId, request)
-
-		locationHeader := fmt.Sprintf(
-			"%s/application-data/influenceData/subs-to-notify/%s",
-			udr_context.GetSelf().GetIPv4GroupUri(udr_context.NUDR_DR), subscriptionId)
-		c.Header("Location", locationHeader)
-		c.JSON(http.StatusCreated, request)
+	target, ok := subscriptionCallbackTargetFromContext(
+		c,
+		models.ServiceName_NPCF_SMPOLICYCONTROL,
+		models.NrfNfManagementNfType_PCF,
+	)
+	if !ok {
+		rejectUnresolvedCallbackTarget(c)
+		return
 	}
+	if value, ok := udrSelf.InfluenceDataSubscriptions.Load(subscriptionId); ok {
+		record, valid := value.(*udr_context.InfluenceDataSubscriptionRecord)
+		if valid {
+			target = record.CallbackTarget
+		}
+		if valid && record.Subscription != nil && reflect.DeepEqual(*request, *record.Subscription) {
+			pd := &models.ProblemDetails{
+				Status: http.StatusForbidden,
+				Cause:  "UNSPECIFIED",
+			}
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+			c.JSON(int(pd.Status), pd)
+			return
+		}
+	}
+
+	udrSelf.InfluenceDataSubscriptions.Store(subscriptionId, &udr_context.InfluenceDataSubscriptionRecord{
+		Subscription:   request,
+		CallbackTarget: target,
+	})
+
+	locationHeader := fmt.Sprintf(
+		"%s/application-data/influenceData/subs-to-notify/%s",
+		udr_context.GetSelf().GetIPv4GroupUri(udr_context.NUDR_DR), subscriptionId)
+	c.Header("Location", locationHeader)
+	c.JSON(http.StatusCreated, request)
 }
 
 func (p *Processor) ApplicationDataInfluenceDataInfluenceIdDeleteProcedure(

--- a/internal/sbi/processor/subs_to_notify_collection.go
+++ b/internal/sbi/processor/subs_to_notify_collection.go
@@ -26,7 +26,19 @@ func (p *Processor) PostSubscriptionDataSubscriptionsProcedure(
 	udrSelf := udr_context.GetSelf()
 
 	newSubscriptionID := strconv.Itoa(udrSelf.SubscriptionDataSubscriptionIDGenerator)
-	udrSelf.SubscriptionDataSubscriptions[newSubscriptionID] = &SubscriptionDataSubscriptions
+	target, ok := subscriptionCallbackTargetFromContext(
+		c,
+		models.ServiceName_NUDM_SDM,
+		models.NrfNfManagementNfType_UDM,
+	)
+	if !ok {
+		rejectUnresolvedCallbackTarget(c)
+		return
+	}
+	udrSelf.SubscriptionDataSubscriptions[newSubscriptionID] = &udr_context.SubscriptionDataSubscriptionRecord{
+		Subscription:   &SubscriptionDataSubscriptions,
+		CallbackTarget: target,
+	}
 	udrSelf.SubscriptionDataSubscriptionIDGenerator++
 
 	/* Contains the URI of the newly created resource, according

--- a/internal/sbi/processor/subscription_callback_target.go
+++ b/internal/sbi/processor/subscription_callback_target.go
@@ -1,0 +1,110 @@
+package processor
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/free5gc/openapi/models"
+	"github.com/free5gc/openapi/nrf/NFManagement"
+	udr_context "github.com/free5gc/udr/internal/context"
+	"github.com/free5gc/udr/internal/logger"
+	udr_util "github.com/free5gc/udr/internal/util"
+	"github.com/free5gc/util/metrics/sbi"
+)
+
+func callbackServiceNameForNfType(
+	nfType models.NrfNfManagementNfType,
+	defaultServiceName models.ServiceName,
+) models.ServiceName {
+	switch nfType {
+	case models.NrfNfManagementNfType_UDM:
+		return models.ServiceName_NUDM_SDM
+	case models.NrfNfManagementNfType_PCF:
+		return defaultServiceName
+	case models.NrfNfManagementNfType_NEF:
+		return models.ServiceName_NNEF_EVENTEXPOSURE
+	default:
+		return defaultServiceName
+	}
+}
+
+func requesterNFTypeFromNRF(nfInstanceID string) (models.NrfNfManagementNfType, bool) {
+	if nfInstanceID == "" {
+		return "", false
+	}
+
+	udrSelf := udr_context.GetSelf()
+	if !udrSelf.OAuth2Required {
+		return "", false
+	}
+
+	ctx, pd, err := udrSelf.GetTokenCtx(models.ServiceName_NNRF_NFM, models.NrfNfManagementNfType_NRF)
+	if err != nil {
+		logger.SBILog.Errorf("Get requester NF profile token failed: %v", err)
+		if pd != nil {
+			logger.SBILog.Errorf("Get requester NF profile token problem details: %+v", pd)
+		}
+		return "", false
+	}
+	if pd != nil {
+		logger.SBILog.Errorf("Get requester NF profile token problem details: %+v", pd)
+		return "", false
+	}
+
+	configuration := NFManagement.NewConfiguration()
+	configuration.SetBasePath(udrSelf.NrfUri)
+	client := NFManagement.NewAPIClient(configuration)
+	request := &NFManagement.GetNFInstanceRequest{}
+	request.SetNfInstanceID(nfInstanceID)
+
+	rsp, err := client.NFInstanceIDDocumentApi.GetNFInstance(ctx, request)
+	if err != nil {
+		logger.SBILog.Errorf("Get requester NF profile [%s] failed: %v", nfInstanceID, err)
+		return "", false
+	}
+	if rsp == nil || rsp.NrfNfManagementNfProfile.NfType == "" {
+		logger.SBILog.Errorf("Get requester NF profile [%s] returned empty NF type", nfInstanceID)
+		return "", false
+	}
+	return rsp.NrfNfManagementNfProfile.NfType, true
+}
+
+func rejectUnresolvedCallbackTarget(c *gin.Context) {
+	pd := models.ProblemDetails{
+		Status: http.StatusUnauthorized,
+		Cause:  "REQUESTER_IDENTITY_UNRESOLVED",
+		Detail: "Unable to resolve requester NF identity for callback token target",
+	}
+	c.Set(sbi.IN_PB_DETAILS_CTX_STR, pd.Cause)
+	c.JSON(int(pd.Status), pd)
+}
+
+func subscriptionCallbackTargetFromContext(
+	c *gin.Context,
+	defaultServiceName models.ServiceName,
+	defaultNfType models.NrfNfManagementNfType,
+) (udr_context.SubscriptionCallbackTarget, bool) {
+	target := udr_context.SubscriptionCallbackTarget{
+		ServiceName: defaultServiceName,
+		NfType:      defaultNfType,
+	}
+
+	if !udr_context.GetSelf().OAuth2Required {
+		return target, true
+	}
+
+	if nfInstanceID, ok := c.Get(udr_util.RequesterNfInstanceIDCtxKey); ok {
+		if nfInstanceID, ok := nfInstanceID.(string); ok {
+			target.NfInstanceID = nfInstanceID
+		}
+	}
+
+	if nfType, ok := requesterNFTypeFromNRF(target.NfInstanceID); ok {
+		target.NfType = nfType
+		target.ServiceName = callbackServiceNameForNfType(nfType, defaultServiceName)
+		return target, true
+	}
+
+	return target, false
+}

--- a/internal/util/router_auth_check.go
+++ b/internal/util/router_auth_check.go
@@ -2,13 +2,45 @@ package util
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 
-	"github.com/free5gc/openapi/models"
+
 	udr_context "github.com/free5gc/udr/internal/context"
 	"github.com/free5gc/udr/internal/logger"
 )
+
+const RequesterNfInstanceIDCtxKey = "requesterNfInstanceId"
+
+type oauth2Requirement interface {
+	OAuth2Enabled() bool
+}
+
+type requesterClaims struct {
+	NfInstanceID string
+}
+
+func parseRequesterClaims(authorization string) (requesterClaims, bool) {
+	fields := strings.Fields(authorization)
+	if len(fields) < 2 {
+		return requesterClaims{}, false
+	}
+
+	claims := jwt.MapClaims{}
+	_, _, err := jwt.NewParser().ParseUnverified(fields[1], claims)
+	if err != nil {
+		return requesterClaims{}, false
+	}
+
+	requester := requesterClaims{}
+	if sub, ok := claims["sub"].(string); ok {
+		requester.NfInstanceID = sub
+	}
+
+	return requester, requester.NfInstanceID != ""
+}
 
 type RouterAuthorizationCheck struct {
 	serviceName models.ServiceName
@@ -28,6 +60,18 @@ func (rac *RouterAuthorizationCheck) Check(c *gin.Context, udrContext udr_contex
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		c.Abort()
 		return
+	}
+
+	if requirement, ok := udrContext.(oauth2Requirement); ok && !requirement.OAuth2Enabled() {
+		logger.UtilLog.Debugf("RouterAuthorizationCheck: OAuth2 disabled, skip requester claims parsing")
+		logger.UtilLog.Debugf("RouterAuthorizationCheck: Check Authorized")
+		return
+	}
+
+	if requester, ok := parseRequesterClaims(token); ok {
+		if requester.NfInstanceID != "" {
+			c.Set(RequesterNfInstanceIDCtxKey, requester.NfInstanceID)
+		}
 	}
 
 	logger.UtilLog.Debugf("RouterAuthorizationCheck: Check Authorized")

--- a/internal/util/router_auth_check.go
+++ b/internal/util/router_auth_check.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 
-
+	"github.com/free5gc/openapi/models"
 	udr_context "github.com/free5gc/udr/internal/context"
 	"github.com/free5gc/udr/internal/logger"
 )


### PR DESCRIPTION
Fix UDR outbound callback notifications missing OAuth2 tokens: https://github.com/free5gc/free5gc/issues/888

**Problem:**

- UDR outbound callback paths (`SendOnDataChangeNotify`, `SendPolicyDataChangeNotification`, `SendInfluenceDataUpdateNotification`) invoke API clients with `context.TODO()`, sending notifications with no `Authorization` header.
- Subscriber NF identity was never recorded at subscription creation time, making it impossible to know which service scope and target NF type to use when requesting a token.

**Fix:**

- Parse the subscriber's NF Instance ID from the `sub` claim of the incoming JWT at subscription creation time (`router_auth_check.go`).
- Look up the subscriber's NF profile from NRF using that instance ID to obtain the authoritative NF type (`subscription_callback_target.go`).
- Store the resolved identity (`NfType`, `ServiceName`) alongside each subscription record in a new `*Record` wrapper struct (`context.go`).
- Replace all `context.TODO()` call sites in the three outbound callback functions with a token context obtained via `GetTokenCtx(serviceName, nfType)` using the stored identity (`callback.go`).
- Reject subscription creation requests where NF identity cannot be resolved when OAuth2 is enabled.