### PR TITLE
fix: validate UDR requests before processing

### DIFF
--- a/internal/sbi/api_datarepository.go
+++ b/internal/sbi/api_datarepository.go
@@ -1211,6 +1211,7 @@ func (s *Server) HandleApplicationDataInfluenceDataSubsToNotifySubscriptionIdDel
 	influenceId := c.Param("influenceId")
 	if influenceId != "subs-to-notify" {
 		c.String(http.StatusNotFound, "404 page not found")
+		return
 	}
 
 	subscriptionId := c.Params.ByName("subscriptionId")
@@ -1225,6 +1226,7 @@ func (s *Server) HandleApplicationDataInfluenceDataSubsToNotifySubscriptionIdGet
 	influenceId := c.Param("influenceId")
 	if influenceId != "subs-to-notify" {
 		c.String(http.StatusNotFound, "404 page not found")
+		return
 	}
 
 	subscriptionId := c.Params.ByName("subscriptionId")
@@ -1237,6 +1239,7 @@ func (s *Server) HandleApplicationDataInfluenceDataSubsToNotifySubscriptionIdPut
 	influenceId := c.Param("influenceId")
 	if influenceId != "subs-to-notify" {
 		c.String(http.StatusNotFound, "404 page not found")
+		return
 	}
 
 	// Get HTTP request body
@@ -1817,7 +1820,15 @@ func (s *Server) HandleCreateSmfContextNon3gpp(c *gin.Context) {
 	}
 	pduSessionId, err := strconv.ParseInt(c.Param("pduSessionId"), 10, 64)
 	if err != nil {
+		problemDetail := models.ProblemDetails{
+			Title:  "Malformed request syntax",
+			Status: http.StatusBadRequest,
+			Detail: "[pduSessionId] " + err.Error(),
+		}
 		logger.DataRepoLog.Warnln(err)
+		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+		c.JSON(http.StatusBadRequest, problemDetail)
+		return
 	}
 
 	s.Processor().CreateSmfContextNon3gppProcedure(c, smfRegistration, collName, ueId, pduSessionId)
@@ -2066,9 +2077,19 @@ func (s *Server) HandleQuerySmData(c *gin.Context) {
 	servingPlmnId := c.Params.ByName("servingPlmnId")
 	singleNssai := models.Snssai{}
 	singleNssaiQuery := c.Query("single-nssai")
-	err := json.Unmarshal([]byte(singleNssaiQuery), &singleNssai)
-	if err != nil {
-		logger.DataRepoLog.Warnln(err)
+	if singleNssaiQuery != "" {
+		err := json.Unmarshal([]byte(singleNssaiQuery), &singleNssai)
+		if err != nil {
+			problemDetail := models.ProblemDetails{
+				Title:  "Malformed request syntax",
+				Status: http.StatusBadRequest,
+				Detail: "[single-nssai] " + err.Error(),
+			}
+			logger.DataRepoLog.Warnln(err)
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+			c.JSON(http.StatusBadRequest, problemDetail)
+			return
+		}
 	}
 
 	dnn := c.Query("dnn")
@@ -2754,6 +2775,7 @@ func (s *Server) HandleApplicationDataInfluenceDataSubsToNotifyGet(c *gin.Contex
 			}
 			c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetails.Status)))
 			c.JSON(http.StatusBadRequest, problemDetails)
+			return
 		}
 	}
 
@@ -2764,6 +2786,7 @@ func (s *Server) HandleApplicationDataInfluenceDataSubsToNotifyGet(c *gin.Contex
 		}
 		c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetails.Status)))
 		c.JSON(http.StatusBadRequest, problemDetails)
+		return
 	}
 
 	s.Processor().ApplicationDataInfluenceDataSubsToNotifyGetProcedure(c, dnn, snssai, internalGroupId, supi)

--- a/internal/sbi/api_datarepository.go
+++ b/internal/sbi/api_datarepository.go
@@ -1818,7 +1818,7 @@ func (s *Server) HandleCreateSmfContextNon3gpp(c *gin.Context) {
 		util.EmptyUeIdProblemJson(c)
 		return
 	}
-	pduSessionId, err := strconv.ParseInt(c.Param("pduSessionId"), 10, 64)
+	pduSessionIdUint, err := strconv.ParseUint(c.Param("pduSessionId"), 10, 8)
 	if err != nil {
 		problemDetail := models.ProblemDetails{
 			Title:  "Malformed request syntax",
@@ -1830,6 +1830,7 @@ func (s *Server) HandleCreateSmfContextNon3gpp(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, problemDetail)
 		return
 	}
+	pduSessionId := int32(pduSessionIdUint)
 
 	s.Processor().CreateSmfContextNon3gppProcedure(c, smfRegistration, collName, ueId, pduSessionId)
 }
@@ -2075,10 +2076,14 @@ func (s *Server) HandleQuerySmData(c *gin.Context) {
 		return
 	}
 	servingPlmnId := c.Params.ByName("servingPlmnId")
-	singleNssai := models.Snssai{}
+	var singleNssai *models.Snssai
 	singleNssaiQuery := c.Query("single-nssai")
 	if singleNssaiQuery != "" {
-		err := json.Unmarshal([]byte(singleNssaiQuery), &singleNssai)
+		query := struct {
+			Sst *int32 `json:"sst"`
+			Sd  string `json:"sd,omitempty"`
+		}{}
+		err := json.Unmarshal([]byte(singleNssaiQuery), &query)
 		if err != nil {
 			problemDetail := models.ProblemDetails{
 				Title:  "Malformed request syntax",
@@ -2090,6 +2095,29 @@ func (s *Server) HandleQuerySmData(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, problemDetail)
 			return
 		}
+		if query.Sst == nil {
+			problemDetail := models.ProblemDetails{
+				Title:  "Malformed request syntax",
+				Status: http.StatusBadRequest,
+				Detail: "[single-nssai.sst] missing required field",
+			}
+			logger.DataRepoLog.Warnln(problemDetail.Detail)
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+			c.JSON(http.StatusBadRequest, problemDetail)
+			return
+		}
+		if *query.Sst < 0 || *query.Sst > 255 {
+			problemDetail := models.ProblemDetails{
+				Title:  "Malformed request syntax",
+				Status: http.StatusBadRequest,
+				Detail: "[single-nssai.sst] must be within the range 0 to 255",
+			}
+			logger.DataRepoLog.Warnln(problemDetail.Detail)
+			c.Set(sbi.IN_PB_DETAILS_CTX_STR, http.StatusText(int(problemDetail.Status)))
+			c.JSON(http.StatusBadRequest, problemDetail)
+			return
+		}
+		singleNssai = &models.Snssai{Sst: *query.Sst, Sd: query.Sd}
 	}
 
 	dnn := c.Query("dnn")

--- a/internal/sbi/processor/session_management_subscription_data.go
+++ b/internal/sbi/processor/session_management_subscription_data.go
@@ -12,7 +12,6 @@ package processor
 import (
 	"encoding/json"
 	"net/http"
-	"reflect"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
@@ -25,11 +24,11 @@ import (
 )
 
 func (p *Processor) QuerySmDataProcedure(c *gin.Context, collName string, ueId string, servingPlmnId string,
-	singleNssai models.Snssai, dnn string,
+	singleNssai *models.Snssai, dnn string,
 ) {
 	filter := bson.M{"ueId": ueId, "servingPlmnId": servingPlmnId}
 
-	if !reflect.DeepEqual(singleNssai, models.Snssai{}) {
+	if singleNssai != nil {
 		if singleNssai.Sd == "" {
 			filter["singleNssai.sst"] = singleNssai.Sst
 		} else {

--- a/internal/sbi/processor/smf_registration_document.go
+++ b/internal/sbi/processor/smf_registration_document.go
@@ -24,13 +24,13 @@ import (
 )
 
 func (p *Processor) CreateSmfContextNon3gppProcedure(c *gin.Context, SmfRegistration models.SmfRegistration,
-	collName string, ueId string, pduSessionIdInt int64,
+	collName string, ueId string, pduSessionId int32,
 ) {
 	putData := util.ToBsonM(SmfRegistration)
 	putData["ueId"] = ueId
-	putData["pduSessionId"] = int32(pduSessionIdInt)
+	putData["pduSessionId"] = pduSessionId
 
-	filter := bson.M{"ueId": ueId, "pduSessionId": pduSessionIdInt}
+	filter := bson.M{"ueId": ueId, "pduSessionId": pduSessionId}
 	existed, err := mongoapi.RestfulAPIPutOne(collName, filter, putData)
 	if err != nil {
 		logger.DataRepoLog.Errorf("CreateSmfContextNon3gppProcedure err: %+v", err)


### PR DESCRIPTION
Fix UDR request validation and fail-open handlers: 
https://github.com/free5gc/free5gc/issues/1113, https://github.com/free5gc/free5gc/issues/1114, https://github.com/free5gc/free5gc/issues/1115, https://github.com/free5gc/free5gc/issues/1116, https://github.com/free5gc/free5gc/issues/1123, https://github.com/free5gc/free5gc/issues/1124

Files:

- `internal/sbi/api_datarepository.go`

Problem:

- Several Traffic Influence Subscription handlers continued processing after returning `400` or `404`, allowing unintended reads, deletes, or writes.
- An invalid `pduSessionId` was treated as `0`, potentially overwriting an existing SMF registration.
- A malformed `single-nssai` was silently treated as an unfiltered query.

Fix:

- Added immediate returns after validation errors.
- Invalid `pduSessionId` and malformed `single-nssai` values now return `400 Bad Request`.